### PR TITLE
Fix "missing _impure_ptr" and more updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,16 @@ RUN apt update && apt install -y \
         python3-pip \
         python3-setuptools \
         zip \
-        gcc-arm-none-eabi \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# GCC ARM
+RUN cd .. && \
+    wget https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 && \
+    tar xjf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 && \
+    echo "PATH=$PATH:/gcc-arm-none-eabi-9-2019-q4-major/bin" >> ~/.bashrc && \
+    cd /app
+
+ENV PATH="/gcc-arm-none-eabi-9-2019-q4-major/bin:${PATH}"
 
 RUN pip3 install pyserial
 RUN pip3 install inquirer

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project contains an exported version of the `Sony Spresense SDK` and requir
 
 * [Edge Impulse CLI](https://docs.edgeimpulse.com/docs/cli-installation).
 * [GNU Make](https://www.gnu.org/software/make/).
-* [GNU ARM Embedded Toolchain 8-2018-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) - make sure `arm-none-eabi-gcc` is in your PATH.
+* [GNU ARM Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) - make sure `arm-none-eabi-gcc` is in your PATH.
 
 ## Building the application
 
@@ -57,12 +57,12 @@ This project contains an exported version of the `Sony Spresense SDK` and requir
 
 Use `screen` or `minicom` to set up a serial connection over USB. Default UART settings are used (115200 baud, 8N1).
 
-## Troubleshooting
+## Tips
 
-**undefined reference to `_impure_ptr'**
+### Override the ARM GNU Toolchain
 
-Make sure you build with [GNU ARM Embedded Toolchain 8-2018-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads). If you have multiple toolchains installed, you can override the compiler via:
+If you have multiple toolchains installed, you can override the compiler via:
 
 ```
-$ CROSS_COMPILE=~/toolchains/gcc-arm-none-eabi-8-2018-q4-major/bin/arm-none-eabi- make -j
+$ CROSS_COMPILE=~/toolchains/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi- make -j
 ```

--- a/stdlib/impure.c
+++ b/stdlib/impure.c
@@ -1,0 +1,28 @@
+#include <reent.h>
+
+/* Note that there is a copy of this in sys/reent.h.  */
+#ifndef __ATTRIBUTE_IMPURE_PTR__
+#define __ATTRIBUTE_IMPURE_PTR__
+#endif
+
+#ifndef __ATTRIBUTE_IMPURE_DATA__
+#define __ATTRIBUTE_IMPURE_DATA__
+#endif
+
+/* Redeclare these symbols locally as weak so that the file containing
+   their definitions (along with a lot of other stuff) isn't sucked in
+   unless they are actually used by other compilation units.  This is
+   important to reduce image size for targets with very small amounts
+   of memory.  */
+#ifdef _REENT_SMALL
+extern const struct __sFILE_fake __sf_fake_stdin _ATTRIBUTE ((weak));
+extern const struct __sFILE_fake __sf_fake_stdout _ATTRIBUTE ((weak));
+extern const struct __sFILE_fake __sf_fake_stderr _ATTRIBUTE ((weak));
+#endif
+
+static struct _reent __ATTRIBUTE_IMPURE_DATA__ impure_data = _REENT_INIT (impure_data);
+#ifdef __CYGWIN__
+extern struct _reent reent_data __attribute__ ((alias("impure_data")));
+#endif
+struct _reent *__ATTRIBUTE_IMPURE_PTR__ _impure_ptr = &impure_data;
+struct _reent *const __ATTRIBUTE_IMPURE_PTR__ _global_impure_ptr = &impure_data;


### PR DESCRIPTION
- Add missing definitions of _impure_ptr
- Use a 9-2019-q4-major GNU Toolchain